### PR TITLE
Make submodules relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = git://github.com/microsoft/vcpkg
+	url = ../../microsoft/vcpkg
 [submodule "clap"]
 	path = clap
-	url = git://github.com/free-audio/clap
+	url = ../clap
 [submodule "clap-helpers"]
 	path = clap-helpers
-	url = git://github.com/free-audio/clap-helpers
+	url = ../clap-helpers


### PR DESCRIPTION
This PR makes the included submodule paths relative to this repo. This fixes an issue with GitHub's recent protocol deprecation. It also makes sure that whatever protocol has been used during cloning the repo will also be used for cloning the submodules.