### PR TITLE
Improve RtMidi dependency handling on Windows

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -4,14 +4,14 @@ set(CMAKE_AUTOMOC ON)
 if (UNIX)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(PortAudio REQUIRED IMPORTED_TARGET portaudio-2.0)
+  pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
 elseif(WIN32)
   find_package(portaudio CONFIG REQUIRED)
+  find_package(RtMidi CONFIG REQUIRED rtmidi)
 endif()
 
 find_package(Qt6Core REQUIRED)
 find_package(Qt6Widgets REQUIRED)
-
-pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
 
 add_executable(clap-host
   application.cc

--- a/host/engine.hh
+++ b/host/engine.hh
@@ -11,7 +11,7 @@
 #include <portaudio.h>
 #include <porttime.h>
 
-#include <rtmidi/RtMidi.h>
+#include <RtMidi.h>
 
 class Application;
 class Settings;

--- a/host/main.cc
+++ b/host/main.cc
@@ -3,7 +3,7 @@
 #include <QApplication>
 
 #include <portaudio.h>
-#include <rtmidi/RtMidi.h>
+#include <RtMidi.h>
 
 #include "application.hh"
 

--- a/host/midi-settings-widget.cc
+++ b/host/midi-settings-widget.cc
@@ -4,7 +4,7 @@
 #include <QGroupBox>
 #include <QVBoxLayout>
 
-#include <rtmidi/RtMidi.h>
+#include <RtMidi.h>
 
 #include "midi-settings-widget.hh"
 #include "midi-settings.hh"


### PR DESCRIPTION
This PR improves RtMidi dependency handling on Windows by:
* changing the `#include`s
* uses find_package on Windows so vcpkg can be used to handle the RtMidi dependency