### PR TITLE
Fix RtMidi/RtAudio via vcpkg and fix redefinition error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0100 NEW)  # handle .hh files
 project(CLAP_HOST C CXX)
 
+set(UsePkgConfig TRUE CACHE BOOL "Use PkgConfig to find RtMidi and RtAudio dependencies")
+
 add_subdirectory(clap)
 add_subdirectory(clap-helpers)
 add_subdirectory(host)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,6 +28,10 @@
         "CMAKE_TOOLCHAIN_FILE": {
           "type": "FILEPATH",
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        },
+        "UsePkgConfig": {
+          "type": "boolean",
+          "value": false
         }
       }
     },
@@ -41,6 +45,10 @@
         "CMAKE_TOOLCHAIN_FILE": {
           "type": "FILEPATH",
           "value": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+        },
+        "UsePkgConfig": {
+          "type": "boolean",
+          "value": false
         }
       }
     }

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -1,10 +1,14 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(PkgConfig REQUIRED)
-
-pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
-pkg_check_modules(RtAudio REQUIRED IMPORTED_TARGET rtaudio)
+if(UsePkgConfig)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
+  pkg_check_modules(RtAudio REQUIRED IMPORTED_TARGET rtaudio)
+else()
+  find_package(RtMidi CONFIG REQUIRED)
+  find_package(RtAudio CONFIG REQUIRED)
+endif()
 
 find_package(Qt6Core CONFIG REQUIRED)
 find_package(Qt6Widgets CONFIG REQUIRED)
@@ -50,7 +54,11 @@ add_executable(clap-host
 
 set_target_properties(clap-host PROPERTIES CXX_STANDARD 17)
 target_link_libraries(clap-host Qt6::Widgets Qt6::Core)
-target_link_libraries(clap-host PkgConfig::RtMidi PkgConfig::RtAudio)
+if(UsePkgConfig)
+  target_link_libraries(clap-host PkgConfig::RtMidi PkgConfig::RtAudio)
+else()
+  target_link_libraries(clap-host RtAudio::rtaudio RtMidi::rtmidi)
+endif()
 target_link_libraries(clap-host clap-core clap-helpers)
 
 if (LINUX)


### PR DESCRIPTION
This PR introduces a new CMake variable that controls whether to find RtMidi and RtAudio via PkgConfig or vcpkg.  
It also fixes a compiler issue (MSVC C2365) in the plugin-host.cc ThreadType enum by converting it to an enum class.