### PR TITLE
Correct mac documentation for building and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ cd clap-host
 
 # Build
 cmake --preset xcode-system
-cmake --build builds\xcode-system --target clap-host --config Release
+cmake --build builds/xcode-system --target clap-host --config Release
 
 # Run
-builds/vs-vcpkg/host/Release/clap-host -p "<path-to-plugin>"
+builds/xcode-system/host/Release/clap-host -p "<path-to-plugin>"
 ```
 
 ### Windows


### PR DESCRIPTION
There's an incorrect path separator in the build line and the path to the build is the same as the windows one (not correct for mac).

This PR corrects these issues.