### PR TITLE
Fix QApplication arguments initialization

### DIFF
--- a/host/application.cc
+++ b/host/application.cc
@@ -17,7 +17,7 @@ Application *Application::_instance = nullptr;
 Q_DECLARE_METATYPE(int32_t)
 Q_DECLARE_METATYPE(uint32_t)
 
-Application::Application(int argc, char **argv)
+Application::Application(int &argc, char **argv)
    : QApplication(argc, argv), _settings(new Settings) {
    assert(!_instance);
    _instance = this;

--- a/host/application.hh
+++ b/host/application.hh
@@ -15,7 +15,7 @@ class Application : public QApplication {
    Q_OBJECT
 
 public:
-   Application(int argc, char **argv);
+   Application(int &argc, char **argv);
    ~Application();
 
    Settings &settings() { return *_settings; }


### PR DESCRIPTION
This PR fixes the declaration of the `Application` constructor to match `QApplication`'s and prevents it from referencing a temporary `argc` variable.

I came across this issue while using the host for testing, and noticed some random segfaults inside `QCoreApplication`'s argument parsing. This change fixed those issues for me.

As an aside, I've also noticed the presence of the `CLAP_HOST_FORCE_PLUGIN` env variable check, perhaps this could be the cause of why arguments are not working in some cases?

Loving CLAP so far by the way, great work! :slightly_smiling_face: 