### PR TITLE
host no longer crashes on quit, when plugin was not instantiated (e.g…

### DIFF
--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -1,4 +1,4 @@
-﻿#include <exception>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -175,8 +175,10 @@ void PluginHost::unload() {
 
    deactivate();
 
-   _plugin->destroy(_plugin);
-   _plugin = nullptr;
+   if (_plugin) {
+      _plugin->destroy(_plugin);
+      _plugin = nullptr;
+   }
    _pluginGui = nullptr;
    _pluginTimerSupport = nullptr;
    _pluginPosixFdSupport = nullptr;


### PR DESCRIPTION
prevents host from crashing on quit in case plugin could not be loaded,  e.g. wrong CLAP version. In that case the _plugin is a nullptr in unload.