### PR TITLE
Actually send the engine <-> app messages

### DIFF
--- a/host/plugin-host.hh
+++ b/host/plugin-host.hh
@@ -144,6 +144,7 @@ private:
 
    void paramFlushOnMainThread();
    void handlePluginOutputEvents();
+   void generatePluginInputEvents();
 
 private:
    Engine &_engine;


### PR DESCRIPTION
The messages to the app were never sent because the queue was
never finished. Similarly, when the host set a value it didn't
call requestFlus so without processing, nothing worked.

So the parameters window works absent an audio loop with this changed!

Still not sure why on mac we don't get an audio callback. but that's
a separate issue