### PR TITLE
Add a test mode where clap-host ignores cookies

### DIFF
--- a/host/application.hh
+++ b/host/application.hh
@@ -44,3 +44,4 @@ private:
    QString _pluginPath;
    int _pluginIndex = 0;
 };
+

--- a/host/main.cc
+++ b/host/main.cc
@@ -4,11 +4,16 @@
 
 #include "application.hh"
 
+bool zeroOutParamCookies{false};
+
 int main(int argc, char *argv[]) {
 
 #ifdef Q_OS_LINUX
    ::setenv("QT_QPA_PLATFORM", "xcb", 1);
 #endif
+
+   if (getenv("ZERO_COOKIES"))
+      zeroOutParamCookies = true;
 
    QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar);
    Application app(argc, argv);

--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -15,6 +15,8 @@
 
 #include <clap/helpers/reducing-param-queue.hxx>
 
+extern bool zeroOutParamCookies;
+
 enum class ThreadType {
    Unknown,
    MainThread,
@@ -798,6 +800,8 @@ void PluginHost::generatePluginInputEvents() {
          ev.header.size = sizeof(ev);
          ev.param_id = param_id;
          ev.cookie = value.cookie;
+         if (zeroOutParamCookies)
+            ev.cookie = nullptr;
          ev.port_index = 0;
          ev.key = -1;
          ev.channel = -1;
@@ -815,6 +819,8 @@ void PluginHost::generatePluginInputEvents() {
       ev.header.size = sizeof(ev);
       ev.param_id = param_id;
       ev.cookie = value.cookie;
+      if (zeroOutParamCookies)
+          ev.cookie = nullptr;
       ev.port_index = 0;
       ev.key = -1;
       ev.channel = -1;
@@ -971,7 +977,9 @@ void PluginHost::setParamValueByHost(PluginParam &param, double value) {
 
    param.setValue(value);
 
-   _appToEngineValueQueue.set(param.info().id, {param.info().cookie, value});
+   auto ck = param.info().cookie;
+   if (zeroOutParamCookies) ck = nullptr;
+   _appToEngineValueQueue.set(param.info().id, {ck, value});
    _appToEngineValueQueue.producerDone();
    clapParamsRequestFlush(&host_);
 }
@@ -981,7 +989,9 @@ void PluginHost::setParamModulationByHost(PluginParam &param, double value) {
 
    param.setModulation(value);
 
-   _appToEngineModQueue.set(param.info().id, {param.info().cookie, value});
+   auto ck = param.info().cookie;
+   if (zeroOutParamCookies) ck = nullptr;
+   _appToEngineModQueue.set(param.info().id, {ck, value});
    _appToEngineModQueue.producerDone();
    clapParamsRequestFlush(&host_);
 }

--- a/host/plugin-param.cc
+++ b/host/plugin-param.cc
@@ -34,7 +34,9 @@ void PluginParam::printInfo(std::ostream &os) const {
 }
 
 bool PluginParam::isInfoEqualTo(const clap_param_info &info) const {
-   return info.cookie == _info.cookie &&
+   extern bool zeroOutParamCookies;
+   bool cookiesSame = zeroOutParamCookies || (info.cookie == _info.cookie);
+   return cookiesSame &&
       info.default_value == _info.default_value &&
       info.max_value == _info.max_value &&
       info.min_value == _info.min_value &&


### PR DESCRIPTION
Add a test mode wher clap-host sets all param cookies to nullptr.