### PR TITLE
Fix for #40

### DIFF
--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -1171,6 +1171,12 @@ void PluginHost::remoteControlsSuggestPage(clap_id page_id) noexcept {
 bool PluginHost::loadNativePluginPreset(const std::string &path) {
    checkForMainThread();
 
+    if(!_plugin)
+    {
+        std::cerr << "called with a null clap_plugin pointer!" << std::endl;
+        return false;
+    }
+
    if (!_plugin->canUsePresetLoad())
       return false;
 


### PR DESCRIPTION
Fix for #40

Guard against null _plugin within PluginHost::loadNativePluginPreset 
Follow error convention in source code

Tested arch: arm64
Confirm no longer crash