### PR TITLE
Fix for #42

### DIFF
--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -265,6 +265,12 @@ static clap_window makeClapWindow(WId window) {
 void PluginHost::setParentWindow(WId parentWindow) {
    checkForMainThread();
 
+    if(!_plugin)
+    {
+        std::cerr << "called with a null clap_plugin pointer!" << std::endl;
+        return;
+    }
+
    if (!_plugin->canUseGui())
       return;
 


### PR DESCRIPTION
Fix for #42 

Guard against null _plugin within PluginHost::setParentWindow 
Follow error convention in source code

Tested arch: arm64
Confirm no longer crash