### PR TITLE
Enable/Disable Menu items based on plugin loaded

### DIFF
--- a/host/main-window.cc
+++ b/host/main-window.cc
@@ -46,7 +46,9 @@ void MainWindow::createMenu() {
 
    QMenu *fileMenu = menuBar->addMenu(tr("File"));
    // TODO: fileMenu->addAction(tr("Load plugin"));
-   connect(fileMenu->addAction(tr("Load Native Plugin Preset")),
+
+   _loadPluginPresetAction = fileMenu->addAction(tr("Load Native Plugin Preset"));
+   connect(_loadPluginPresetAction,
            &QAction::triggered,
            this,
            &MainWindow::loadNativePluginPreset);
@@ -62,11 +64,15 @@ void MainWindow::createMenu() {
            &Application::quit);
 
    auto windowsMenu = menuBar->addMenu("Windows");
-   connect(windowsMenu->addAction(tr("Show Parameters")),
+
+   _showPluginParametersAction = windowsMenu->addAction(tr("Show Parameters"));
+   connect(_showPluginParametersAction,
            &QAction::triggered,
            this,
            &MainWindow::showPluginParametersWindow);
-   connect(windowsMenu->addAction(tr("Show Quick Controls")),
+
+   _showPluginQuickControlsAction = windowsMenu->addAction(tr("Show Quick Controls"));
+   connect(_showPluginQuickControlsAction,
            &QAction::triggered,
            this,
            &MainWindow::showPluginQuickControlsWindow);
@@ -76,11 +82,15 @@ void MainWindow::createMenu() {
       dialog.exec();
    });
    menuBar->addSeparator();
-   connect(windowsMenu->addAction(tr("Toggle Plugin Window Visibility")),
+
+   _togglePluginWindowVisibilityAction = windowsMenu->addAction(tr("Toggle Plugin Window Visibility"));
+   connect(_togglePluginWindowVisibilityAction,
            &QAction::triggered,
            this,
            &MainWindow::togglePluginWindowVisibility);
-   connect(windowsMenu->addAction(tr("Recreate Plugin Window")),
+
+   _recreatePluginWindowAction = windowsMenu->addAction(tr("Recreate Plugin Window"));
+   connect(_recreatePluginWindowAction,
            &QAction::triggered,
            this,
            &MainWindow::recreatePluginWindow);
@@ -88,6 +98,16 @@ void MainWindow::createMenu() {
    QMenu *helpMenu = menuBar->addMenu(tr("Help"));
    connect(
       helpMenu->addAction(tr("About")), &QAction::triggered, this, &MainWindow::showAboutDialog);
+
+   updateMenuItems();
+}
+
+void MainWindow::updateMenuItems() {
+   _loadPluginPresetAction->setEnabled(_pluginLoaded);
+   _showPluginParametersAction->setEnabled(_pluginLoaded);
+   _showPluginQuickControlsAction->setEnabled(_pluginLoaded);
+   _togglePluginWindowVisibilityAction->setEnabled(_pluginLoaded);
+   _recreatePluginWindowAction->setEnabled(_pluginLoaded);
 }
 
 void MainWindow::showSettingsDialog() {
@@ -115,6 +135,11 @@ void MainWindow::resizePluginView(int width, int height) {
    _pluginViewWidget->setFixedSize(sw, sh);
    _pluginViewWidget->show();
    adjustSize();
+}
+
+void MainWindow::onPluginLoadChange(bool const i_pluginLoaded) {
+   _pluginLoaded = i_pluginLoaded;
+   updateMenuItems();
 }
 
 void MainWindow::loadNativePluginPreset() {

--- a/host/main-window.cc
+++ b/host/main-window.cc
@@ -99,15 +99,18 @@ void MainWindow::createMenu() {
    connect(
       helpMenu->addAction(tr("About")), &QAction::triggered, this, &MainWindow::showAboutDialog);
 
-   updateMenuItems();
+   updatePluginMenuItems();
+
+   assert(_application.engine());
+   connect(&_application.engine()->pluginHost(), &PluginHost::pluginLoadedChanged, this, &MainWindow::updatePluginMenuItems);
 }
 
-void MainWindow::updateMenuItems() {
-   _loadPluginPresetAction->setEnabled(_pluginLoaded);
-   _showPluginParametersAction->setEnabled(_pluginLoaded);
-   _showPluginQuickControlsAction->setEnabled(_pluginLoaded);
-   _togglePluginWindowVisibilityAction->setEnabled(_pluginLoaded);
-   _recreatePluginWindowAction->setEnabled(_pluginLoaded);
+void MainWindow::updatePluginMenuItems(bool const pluginLoaded /* = false */ ) {
+   _loadPluginPresetAction->setEnabled(pluginLoaded);
+   _showPluginParametersAction->setEnabled(pluginLoaded);
+   _showPluginQuickControlsAction->setEnabled(pluginLoaded);
+   _togglePluginWindowVisibilityAction->setEnabled(pluginLoaded);
+   _recreatePluginWindowAction->setEnabled(pluginLoaded);
 }
 
 void MainWindow::showSettingsDialog() {
@@ -135,11 +138,6 @@ void MainWindow::resizePluginView(int width, int height) {
    _pluginViewWidget->setFixedSize(sw, sh);
    _pluginViewWidget->show();
    adjustSize();
-}
-
-void MainWindow::onPluginLoadChange(bool const i_pluginLoaded) {
-   _pluginLoaded = i_pluginLoaded;
-   updateMenuItems();
 }
 
 void MainWindow::loadNativePluginPreset() {

--- a/host/main-window.hh
+++ b/host/main-window.hh
@@ -25,7 +25,6 @@ public:
    void showPluginParametersWindow();
    void showPluginQuickControlsWindow();
    void resizePluginView(int width, int height);
-   void onPluginLoadChange(bool i_pluginLoaded);
 
    void showPluginWindow() { _pluginViewWidget->show(); }
 
@@ -42,7 +41,7 @@ private:
    void togglePluginWindowVisibility();
    void recreatePluginWindow();
    void showAboutDialog();
-   void updateMenuItems();
+   void updatePluginMenuItems(bool pluginLoaded = false);
 
    Application &_application;
    QWindow *_pluginViewWindow = nullptr;
@@ -53,8 +52,6 @@ private:
    QAction *_showPluginQuickControlsAction = nullptr;
    QAction *_togglePluginWindowVisibilityAction = nullptr;
    QAction *_recreatePluginWindowAction = nullptr;
-
-   bool _pluginLoaded = false;
 
    PluginParametersWidget *_pluginParametersWidget = nullptr;
    PluginQuickControlsWidget *_pluginRemoteControlsWidget = nullptr;

--- a/host/main-window.hh
+++ b/host/main-window.hh
@@ -25,6 +25,7 @@ public:
    void showPluginParametersWindow();
    void showPluginQuickControlsWindow();
    void resizePluginView(int width, int height);
+   void onPluginLoadChange(bool i_pluginLoaded);
 
    void showPluginWindow() { _pluginViewWidget->show(); }
 
@@ -41,10 +42,19 @@ private:
    void togglePluginWindowVisibility();
    void recreatePluginWindow();
    void showAboutDialog();
+   void updateMenuItems();
 
    Application &_application;
    QWindow *_pluginViewWindow = nullptr;
    QWidget *_pluginViewWidget = nullptr;
+
+   QAction *_loadPluginPresetAction = nullptr;
+   QAction *_showPluginParametersAction = nullptr;
+   QAction *_showPluginQuickControlsAction = nullptr;
+   QAction *_togglePluginWindowVisibilityAction = nullptr;
+   QAction *_recreatePluginWindowAction = nullptr;
+
+   bool _pluginLoaded = false;
 
    PluginParametersWidget *_pluginParametersWidget = nullptr;
    PluginQuickControlsWidget *_pluginRemoteControlsWidget = nullptr;

--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -148,7 +148,7 @@ bool PluginHost::load(const QString &path, int pluginIndex) {
    scanParams();
    scanQuickControls();
 
-   Application::instance().mainWindow()->onPluginLoadChange(true);
+   pluginLoadedChanged(true);
 
    return true;
 }
@@ -156,7 +156,7 @@ bool PluginHost::load(const QString &path, int pluginIndex) {
 void PluginHost::unload() {
    checkForMainThread();
 
-   Application::instance().mainWindow()->onPluginLoadChange(false);
+   pluginLoadedChanged(false);
 
    if (!_library.isLoaded())
       return;

--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -147,11 +147,16 @@ bool PluginHost::load(const QString &path, int pluginIndex) {
 
    scanParams();
    scanQuickControls();
+
+   Application::instance().mainWindow()->onPluginLoadChange(true);
+
    return true;
 }
 
 void PluginHost::unload() {
    checkForMainThread();
+
+   Application::instance().mainWindow()->onPluginLoadChange(false);
 
    if (!_library.isLoaded())
       return;
@@ -1170,12 +1175,6 @@ void PluginHost::remoteControlsSuggestPage(clap_id page_id) noexcept {
 
 bool PluginHost::loadNativePluginPreset(const std::string &path) {
    checkForMainThread();
-
-    if(!_plugin)
-    {
-        std::cerr << "called with a null clap_plugin pointer!" << std::endl;
-        return false;
-    }
 
    if (!_plugin->canUsePresetLoad())
       return false;

--- a/host/plugin-host.hh
+++ b/host/plugin-host.hh
@@ -92,6 +92,7 @@ signals:
    void quickControlsPagesChanged();
    void quickControlsSelectedPageChanged();
    void paramAdjusted(clap_id paramId);
+   void pluginLoadedChanged(bool pluginLoaded);
 
 protected:
    /////////////////////////


### PR DESCRIPTION
Per @Trinitou suggestions, a plugin specific menu item should only be enabled (available to execute by user) when the plugin is loaded, and disabled when the plugin is not loaded

## Fixes  
This fixes the underlying cause of the crashes reported in #40 and #42
Fix for #40 
Fix for #42 

## Details  
Upon plugin load change we update the menu items  
Reverts the now obsolete change in previous merged pull request #43 
Tab indentation set to 3 to be consistent with existing code
Note: Follows the QT memory ownership model, and the QAction pointers lifetime is handled by their parents

## Testing  
Arm64 Debug
1. Launch with no plugin loaded, see menu items are greyed out (disabled), 
user cannot select these items (as intended) therefore code is not executed and app doesn't crash
2. Launch with plugin loaded, see menu items are available and executed when user clicks
confirm still no crashes

## Test 1: Plugin not loaded  
<img width="481" alt="MenuItemPluginNotLoaded1" src="https://github.com/free-audio/clap-host/assets/150625586/4ca6edc2-e9c8-44e7-b8a8-f30aa8dba215">  
<img width="486" alt="MenuItemPluginNotLoaded2" src="https://github.com/free-audio/clap-host/assets/150625586/701e95b4-84da-4c5b-bd43-9b51d34d61f9">   

## Test 2: Plugin loaded  
<img width="503" alt="MenuItemPluginLoaded1" src="https://github.com/free-audio/clap-host/assets/150625586/b7869f1e-1a7a-4d4d-b25f-80626becc267">  
<img width="503" alt="MenuItemPluginLoaded2" src="https://github.com/free-audio/clap-host/assets/150625586/fd15c6a5-e148-4a2e-8dd2-72104252a0d1">  
