### PR TITLE
fix: rename clap plugin path command line option to avoid collision with built-in Qt option.

### DIFF
--- a/host/application.cc
+++ b/host/application.cc
@@ -38,16 +38,6 @@ Application::Application(int &argc, char **argv)
 
    _engine->setParentWindow(_mainWindow->getEmbedWindowId());
 
-   /*
-    * This is here JUST because macOS and QT don't process command lines properly
-    * and I'm not sure why yet.
-    */
-   if (getenv("CLAP_HOST_FORCE_PLUGIN")) {
-      qWarning() << "Warning: Loading plugin from ENV, not command line";
-      _pluginPath = getenv("CLAP_HOST_FORCE_PLUGIN");
-      _pluginIndex = 0;
-   }
-
    if (_engine->loadPlugin(_pluginPath, _pluginIndex))
       _engine->start();
 }
@@ -68,9 +58,11 @@ Application::~Application() {
 void Application::parseCommandLine() {
    QCommandLineParser parser;
 
+   // --plugin is a built-in QGuiApplication option, so we use clap-plugin here to avoid the collision.
+   // https://doc.qt.io/qt-6/qguiapplication.html#supported-command-line-options
    QCommandLineOption pluginOpt(QStringList() << "p"
-                                              << "plugin",
-                                tr("path to the plugin"),
+                                              << "clap-plugin",
+                                tr("path to the CLAP plugin"),
                                 tr("path"));
    QCommandLineOption pluginIndexOpt(QStringList() << "i"
                                                    << "plugin-index",


### PR DESCRIPTION
`QtGuiApplication` provides built-in command line flags that clobber any user-specified flags of the same name. `--plugin` is one of them (viewable via `./clap-host --help-all`); see [docs here](https://doc.qt.io/qt-6/qguiapplication.html#supported-command-line-options). So I renamed it to `--clap-plugin` to avoid that, while keeping the `-p` short flag.

I'm usually hesitant to change something as major as a flag name, but I figure changing the long name is okay because it never worked in the first place. Some considerations:

- You could do something sneaky to preprocess `argv` if you really wanted to maintain the `--plugin` long name, but that's pretty surprising behavior.
- This would probably suggest some kind of version bump, depending on how y'all usually do such things.
- Happy to rename `plugin-index` to `clap-plugin-index` for mild name consistency.
- I got rid of the `CLAP_HOST_FORCE_PLUGIN` because it seemed like, based on the comment, it was there to compensate for the nonfunctioning `--plugin` argument.