### PR TITLE
Misc one-liner fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt6Widgets CONFIG REQUIRED)
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "AppleClang|Clang|GNU")
   add_compile_options(-fvisibility=hidden -fvisibility-inlines-hidden
-    -Werror=return-type -Werror=unused-result -Wno-unused-parameter
+    -Werror=return-type -Werror=unused-result -Wno-unused-parameter -Wno-terminate
     -Wuninitialized -Wvla -Wmultichar -Werror=non-virtual-dtor -Woverloaded-virtual)
 endif()
 

--- a/host/engine.cc
+++ b/host/engine.cc
@@ -94,6 +94,8 @@ void Engine::start() {
       _audio.reset();
       _audio =
          std::make_unique<RtAudio>(RtAudio::getCompiledApiByName(deviceRef._api.toStdString()));
+
+      qInfo() << "Loading with Audio API:" << deviceRef._api;
       if (_audio) {
          const auto deviceIds = _audio->getDeviceIds();
          if (deviceIds.empty()) {

--- a/host/engine.cc
+++ b/host/engine.cc
@@ -38,7 +38,7 @@ Engine::Engine(Application &application)
 }
 
 Engine::~Engine() {
-   std::clog << "     ####### STOPING ENGINE #########" << std::endl;
+   std::clog << "     ####### STOPPING ENGINE #########" << std::endl;
    stop();
    unloadPlugin();
    std::clog << "     ####### ENGINE STOPPED #########" << std::endl;
@@ -114,6 +114,13 @@ void Engine::start() {
          if (!deviceId.has_value()) {
             // At least we can try something...
             deviceId = _audio->getDefaultOutputDevice();
+         }
+
+         const auto deviceInfo = _audio->getDeviceInfo(deviceId.value());
+         const auto& validSampleRates = deviceInfo.sampleRates;
+         if (std::find(validSampleRates.begin(), validSampleRates.end(), as.sampleRate()) == validSampleRates.end()) {
+            qWarning() << "The requested sample rate " << as.sampleRate() << " isn't supported by the selected output. Defaulting to " << deviceInfo.preferredSampleRate;
+            as.setSampleRate(deviceInfo.preferredSampleRate);
          }
 
          RtAudio::StreamParameters outParams;

--- a/host/plugin-host.cc
+++ b/host/plugin-host.cc
@@ -132,6 +132,8 @@ bool PluginHost::load(const QString &path, int pluginIndex) {
       return false;
    }
 
+   qInfo() << "Loading plugin with id:" << desc->id << "index:" << pluginIndex;
+
    const auto plugin = _pluginFactory->create_plugin(_pluginFactory, clapHost(), desc->id);
    if (!plugin) {
       qWarning() << "could not create the plugin with id: " << desc->id;
@@ -592,8 +594,6 @@ void PluginHost::processNoteOn(int sampleOffset, int channel, int key, int veloc
    ev.note_id = -1;
    ev.velocity = velocity / 127.0;
 
-   qInfo() << "NoteOn {key" << ev.key << ", velocity: " << ev.velocity
-           << ", channel: " << ev.channel << "}";
    _evIn.push(&ev.header);
 }
 
@@ -612,8 +612,6 @@ void PluginHost::processNoteOff(int sampleOffset, int channel, int key, int velo
    ev.note_id = -1;
    ev.velocity = velocity / 127.0;
 
-   qInfo() << "NoteOff {key" << ev.key << ", velocity: " << ev.velocity
-           << ", channel: " << ev.channel << "}";
    _evIn.push(&ev.header);
 }
 
@@ -667,9 +665,7 @@ void PluginHost::process() {
 
    // We can't process a plugin which failed to start processing
    if (_state == ActiveWithError)
-   {
       return;
-   }
 
    _process.transport = nullptr;
 
@@ -686,11 +682,9 @@ void PluginHost::process() {
 
    if (isPluginSleeping()) {
       if (!_scheduleProcess && _evIn.empty())
-      {
          // The plugin is sleeping, there is no request to wake it up and there are no events to
          // process
          return;
-      }
 
       _scheduleProcess = false;
       if (!_plugin->startProcessing()) {


### PR DESCRIPTION
fix: off-by-one error when checking if a plugin index is valid
fix: if an invalid sample rate is selected, the program can go into a broken state. default to the output devices preferred sample rate in that case.
nit: enable -Wno-terminate. silences "your call to std::logic_error will terminate the program without an exception handler"-type errors.
nit: Log the loaded plugin id to console

found while using clap-host to validate my clap plugin implementation. there are some features I'd also like to add, like picking the plugin by id instead of index and maybe a system to play some reference audio into the input ports for effects. maybe later!