### PR TITLE
fix: prevent invalid array access when no device is selected

### DIFF
--- a/host/audio-settings-widget.cc
+++ b/host/audio-settings-widget.cc
@@ -114,7 +114,7 @@ void AudioSettingsWidget::updateSampleRateList() {
    bool didSelectSampleRate = false;
    auto deviceIds = _audio->getDeviceIds();
    const auto index = _deviceChooser->currentIndex();
-   if (index != -1)
+   if (index == -1)
       return;
 
    auto info = _audio->getDeviceInfo(deviceIds[index]);
@@ -204,8 +204,11 @@ void AudioSettingsWidget::saveSettings() {
    if (_isRefreshingDeviceList)
       return;
 
+   const auto deviceIds = _audio->getDeviceIds();
    int index = _deviceChooser->currentIndex();
-   auto deviceInfo = _audio->getDeviceInfo(index);
+   if(index == -1)
+      return;
+   auto deviceInfo = _audio->getDeviceInfo(deviceIds[index]);
 
    DeviceReference ref;
    auto apiName = RtAudio::getApiName(getSelectedAudioApi());


### PR DESCRIPTION
Fixes an issue where an invalid device index could be used when no device is selected.

`_deviceChooser->currentIndex()` returns -1 when no device is selected.
The previous condition used `!= -1` which allowed execution to continue with an invalid index, potentially leading to invalid array access and also preventing population of the sample rate combo box within the settings menu.

This change updates the condition to return immediately when `index == -1`.

Also fixed `AudioSettingsWidget::saveSettings()` to use `deviceId` instead of `index` when calling `RtAudio::getDeviceInfo(unsigned int deviceId)`.